### PR TITLE
Generate \author commands that addAuthTiProduction.py can parse

### DIFF
--- a/papers/add_tex_via_docx.py
+++ b/papers/add_tex_via_docx.py
@@ -76,7 +76,7 @@ for currLine in temp_tex.split("\n"):
 	if m_title:
 		tex += "\\title{" + title + "}\n"
 	elif m_author:
-		tex += "\\author{" +  author + "}\n"
+		tex += "\\author[" +  author + "]\n"
 	else:
 		tex += currLine + "\n"
 


### PR DESCRIPTION
Without this fix authors names may be extracted from Word files, but always appear as `AUTHOR` in the proceedings.